### PR TITLE
Clarified meaning of storage optimized

### DIFF
--- a/includes/virtual-machines-common-sizes-storage.md
+++ b/includes/virtual-machines-common-sizes-storage.md
@@ -14,6 +14,9 @@ Storage optimized VM sizes offer high disk throughput and IO, and are ideal for 
 
 The Ls-series offers up to 32 vCPUs, using the [Intel® Xeon® processor E5 v3 family](http://www.intel.com/content/www/us/en/processors/xeon/xeon-e5-solutions.html). The Ls-series gets the same CPU performance as the G/GS-Series and comes with 8 GiB of memory per vCPU.  
 
+> [!NOTE]
+> The Ls-series is optimized for use of the temporary disk attached to the VM rather than use of durable data disks. The high throughput and IOPS of the temporary disk makes the Ls-series ideal for NoSQL stores such as Apache Cassandra and MongoDB which replicate data across multiple VMs to achieve persistence in the event of the failure of a single VM. The Ls-series does not support the creation of a local cache to increase the IOPS achievable by durable data disks.
+
 ## Ls-series
 
 ACU: 180-240


### PR DESCRIPTION
Added a note to clarify that storage optimized refers to the use of the temporary disk rather than durable data disks attached to the VM